### PR TITLE
Fix invalid symlink

### DIFF
--- a/src/cursorList
+++ b/src/cursorList
@@ -48,7 +48,7 @@ left_ptr_watch progress
 left_side left-arrow
 link alias
 move dnd-move
-n-resize size-size_ver
+n-resize size_ver
 no-drop not-allowed
 plus cell
 pointing_hand pointer


### PR DESCRIPTION
https://github.com/clayrisser/breeze-hacked-cursor-theme/blob/2e4a1da40405b04290c3a690703e28f07598cbd3/src/cursorList#L51
I noticed that symling `n-resize -> size-size_ver` is not valid. File `size-size_ver` does not exist.