### PR TITLE
Redirect error outputs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,11 +59,11 @@ for CUR in src/config/*.cursor; do
 	echo -ne "\033[0KGenerating simple cursor pixmaps... $BASENAME\\r"
 
 	if [ "$DIR1X/$BASENAME.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i $BASENAME -d 90 --export-filename "$DIR1X/$BASENAME.png" > /dev/null
+		inkscape $RAWSVG -i $BASENAME -d 90 --export-filename "$DIR1X/$BASENAME.png" 2> /dev/null
 	fi
 
 	if [ "$DIR2X/$BASENAME.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i $BASENAME -d 180 --export-filename "$DIR2X/$BASENAME.png" > /dev/null
+		inkscape $RAWSVG -i $BASENAME -d 180 --export-filename "$DIR2X/$BASENAME.png" 2> /dev/null
 	fi
 done
 echo -e "\033[0KGenerating simple cursor pixmaps... DONE"
@@ -75,19 +75,19 @@ do
 	echo -ne "\033[0KGenerating animated cursor pixmaps... $i / 23 \\r"
 
 	if [ "$DIR1X/progress-$i.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i progress-$i -d 90 --export-filename "$DIR1X/progress-$i.png" > /dev/null
+		inkscape $RAWSVG -i progress-$i -d 90 --export-filename "$DIR1X/progress-$i.png" 2> /dev/null
 	fi
 
 	if [ "$DIR2X/progress-$i.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i progress-$i -d 180 --export-filename "$DIR2X/progress-$i.png" > /dev/null
+		inkscape $RAWSVG -i progress-$i -d 180 --export-filename "$DIR2X/progress-$i.png" 2> /dev/null
 	fi
 
 	if [ "$DIR1X/wait-$i.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i wait-$i -d 90 --export-filename "$DIR1X/wait-$i.png" > /dev/null
+		inkscape $RAWSVG -i wait-$i -d 90 --export-filename "$DIR1X/wait-$i.png" 2> /dev/null
 	fi
 
 	if [ "$DIR2X/wait-$i.png" -ot $RAWSVG ] ; then
-		inkscape $RAWSVG -i wait-$i -d 180 --export-filename "$DIR2X/wait-$i.png" > /dev/null
+		inkscape $RAWSVG -i wait-$i -d 180 --export-filename "$DIR2X/wait-$i.png" 2> /dev/null
 	fi
 done
 echo -e "\033[0KGenerating animated cursor pixmaps... DONE"


### PR DESCRIPTION
Inkscape generates a lot of warnings to the error output. [errors.log](https://github.com/clayrisser/breeze-hacked-cursor-theme/files/7565060/errors.log)

It consists mainly of:
```
** (org.inkscape.Inkscape:31829): WARNING **: 19:08:49.380: Ignoring unrecognized CSS property: block-progression
```

Redirecting errors with `2> /dev/null` solves this and leads to clean output:

```
$ ./build.sh
Checking Requirements... DONE
Making Folders... DONE
Generating simple cursor pixmaps... DONE
Generating animated cursor pixmaps... DONE
Generating cursor theme... DONE
Generating shortcuts... DONE
Copying Theme Index... DONE
COMPLETE!
```