### PR TITLE
convert build.sh to python in order to facilitate a more flexible build system.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ build: Breeze_Hacked
 	@echo ::: CLEAN :::
 
 Breeze_Hacked:
-	@./build.sh
+	@./build.py

--- a/build.py
+++ b/build.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from pathlib import Path
 from shutil import which, copy
 from subprocess import Popen, DEVNULL, PIPE
@@ -77,11 +78,20 @@ for cursor in cursorpositions:
             name = nametemplate.format(i + 1)
             outfile = scaledir / f"{name}.png"
             picprocs.append(
-                Popen(["inkscape", SVG.as_posix(), "-i", name, "-d", f"{dpi * scale}", "-o", outfile.as_posix()], stderr=DEVNULL)
+                Popen([
+                    "inkscape",
+                    SVG.as_posix(),
+                    "-i", name,
+                    "-d", f"{dpi * scale:f}",
+                    "-o", outfile.as_posix()],
+                    stderr=PIPE,
+                    env={"SELF_CALL":"AAAAH"}
+                )
             )
 
 for p in picprocs:
-    p.wait()
+    if p.wait() != 0:
+        print(p.returncode, p.stderr.read())
 
 print("\033[0KGenerating cursor pixmaps... DONE")
 

--- a/build.py
+++ b/build.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from shutil import which, copy
+from subprocess import Popen, DEVNULL, PIPE
+
+src = Path("src")
+size=24 # size at 1x scale
+dpi=90 # dpi at 1x scale
+scales = [1, 1.5, 2]
+
+SVG = src / "cursors.svg"
+INDEX = src / "index.theme"
+ALIASES= src / "cursorList"
+
+########### PARSE CONFIGS ###########
+config = src  / "config"
+
+cursorpositions = {}
+for c in config.iterdir():
+    with open(c, "r") as f:
+        cursorpositions[c.stem] = [ tuple(map(int, s.split()[1:3]))
+                                    for s in f if s.startswith(f"{size}")]
+
+with open(INDEX) as ind:
+    ind.readline()
+    line = ind.readline().strip()
+    OUTPUT = Path(".") / line.split("=")[1].replace(" ", "_")
+
+
+########### REQUIREMENTS ###########
+print("Checking Requirements...", end="\r", flush=True)
+
+if not SVG.exists():
+    print(f"\nFAIL: {SVG} missing in src")
+    exit(1)
+
+if not INDEX.exists():
+    print(f"\nFAIL: {INDEX} missing in src")
+    exit(1)
+
+if which("inkscape") is None:
+    print("\nFAIL: inkscape must be intalled")
+
+if which("xcursorgen") is None:
+    print("\nFAIL: xcursorgen must be intalled")
+
+print("Checking Requirements... DONE")
+
+
+########### FOLDERS ###########
+print("Making Folders...", end="", flush=True)
+build = Path("build")
+build.mkdir(exist_ok=True)
+
+for s in scales:
+    (build / f"x{s}").mkdir(exist_ok=True)
+
+OUTPUT.mkdir(exist_ok=True)
+(OUTPUT / "cursors").mkdir(exist_ok=True)
+
+print("DONE")
+
+
+########### PIXMAPS ###########
+
+picprocs = []
+
+for cursor in cursorpositions:
+    print(f"\033[0KGenerating cursor pixmaps... {cursor}", end="\r", flush=True)
+    positions = cursorpositions[cursor]
+    nametemplate = f"{cursor}"
+    if len(positions) > 1:
+        nametemplate = f"{cursor}-{{:02}}"
+
+    for scale in scales:
+        scaledir = build / f"x{scale}"
+        for i, _ in enumerate(positions):
+            name = nametemplate.format(i + 1)
+            outfile = scaledir / f"{name}.png"
+            picprocs.append(
+                Popen(["inkscape", SVG.as_posix(), "-i", name, "-d", f"{dpi * scale}", "-o", outfile.as_posix()], stderr=DEVNULL)
+            )
+
+for p in picprocs:
+    p.wait()
+
+print("\033[0KGenerating cursor pixmaps... DONE")
+
+
+########### THEME ###########
+for cursor in cursorpositions:
+    print(f"Generating cursor theme... {cursor}\r", end="", flush=True)
+    poss = cursorpositions[cursor]
+    multi = len(poss) > 1
+    message ="\n".join(
+        f"{scale * size:.0f} {scale * x:.0f} {scale * y:.0f} x{scale}/{cursor}{f"-{i + 1:02}" if multi else ""}.png {"30" if multi else ""}"
+            for scale in scales
+            for i, (x, y) in enumerate(poss)
+    )
+
+    gen = Popen(["xcursorgen", "-p", "build", "-", (OUTPUT / "cursors" / cursor).as_posix()], stdin=PIPE)
+    gen.communicate(bytes(message, encoding="utf8"))
+
+print("Generating cursor theme... DONE                   ")
+
+
+########### SHORTCUTS ###########
+
+print("Generating shortcuts...", end="", flush=True)
+
+cursors = OUTPUT / "cursors"
+with open(ALIASES) as aliases:
+    for alias in aliases:
+        src, dst = alias.split()
+        src = cursors / src
+        if not src.exists():
+            src.symlink_to(dst)
+
+print("DONE")
+
+########### INDEX ###########
+
+print("Copying Theme Index...\r", end="", flush=True)
+
+copy(src= INDEX, dst= OUTPUT / "index.theme")
+
+print("\033[0KCopying Theme Index... DONE")
+
+print("COMPLETE!")


### PR DESCRIPTION
This is honestly just a small utility I did for my own sake, so if you do not find this to be an aporpriate addition please close the PR, but I at least want to offer to share. 

### why did I do this?
bash is kinda horrible to write and as both a regular user and a user of fractional scaling it has always bothered me, that Breeze Hacked only comes in 1x or 2x scale. This would've been fine if not for GNOME (masters of inferior technical solutions). 
Under wayland gtk4 clients draw the cursor themselves and will refuse to scale the cursor if there's no smaller version available. 
It's also just nice to have more options. 
to facilitate this flexibility I've rewritten build.sh in python. 

### the result
adding more scale factors or cursor sizes is now very easy and basically everything can now be parametrized at the start of the build file. 
there's also improved performance due to subprocess calls no longer blocking

### outstanding issues
I'm currently very roughly parsing the cursor config files in order to get the cursor positions. 
This could be done in a less scuffed way.
