### PR TITLE
fix bug in inkscape behaviour

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from shutil import which, copy
 from subprocess import Popen, DEVNULL, PIPE
+from os import environ
 
 src = Path("src")
 size=24 # size at 1x scale
@@ -85,7 +86,7 @@ for cursor in cursorpositions:
                     "-d", f"{dpi * scale:f}",
                     "-o", outfile.as_posix()],
                     stderr=PIPE,
-                    env={"SELF_CALL":"AAAAH"}
+                    env={**environ, "SELF_CALL":"AAAAH"} # this is a workaround to run inkscape in parallel
                 )
             )
 


### PR DESCRIPTION
pass along preexisting env variables to inkscape. This fixes some inkscape misbehaviour. 

I encountered this issue when building on gentoo using ebuild. 
I don't know why this is the solution but surely this fix imnproves general behaviour and brings inkscape's environment in line with the previous build file so it's for sure a good idea.