### PR TITLE
Add missing grab and resize cursor aliases

### DIFF
--- a/src/cursorList
+++ b/src/cursorList
@@ -35,6 +35,7 @@ dnd-none dnd-move
 dnd-no-drop not-allowed
 draft pencil
 e-resize size_hor
+ew-resize size_hor
 forbidden no-drop
 grab openhand
 grabbing closedhand
@@ -53,6 +54,11 @@ lr_angle bottom_right_corner
 link alias
 move dnd-move
 n-resize size_ver
+ne-resize size_bdiag
+nesw-resize size_bdiag
+ns-resize size_ver
+nw-resize size_fdiag
+nwse-resize size_fdiag
 no-drop not-allowed
 plus cell
 pointing_hand pointer
@@ -61,6 +67,8 @@ right_ptr default
 right_side right-arrow
 row-resize size_ver
 s-resize size_ver
+se-resize size_fdiag
+sw-resize size_bdiag
 sb_h_double_arrow size_hor
 sb_v_double_arrow size_ver
 sb_up_arrow up-arrow

--- a/src/cursorList
+++ b/src/cursorList
@@ -36,6 +36,8 @@ dnd-no-drop not-allowed
 draft pencil
 e-resize size_hor
 forbidden no-drop
+grab openhand
+grabbing closedhand
 h_double_arrow size_hor
 half-busy progress
 hand1 pointer


### PR DESCRIPTION
Properly maps missing cursors so applications using CSS cursor names resolve to the correct theme cursors instead of falling back to system defaults.